### PR TITLE
[benchmark] Determine volume mount paths deterministically for Helix Core userdata | 69002

### DIFF
--- a/terraform/azure/clients.tf
+++ b/terraform/azure/clients.tf
@@ -36,8 +36,7 @@ resource "azurerm_linux_virtual_machine" "locustclients" {
   network_interface_ids = [
     azurerm_network_interface.clients_network_interface[count.index].id,
   ]
-  user_data                  = local.client_user_data
-  encryption_at_host_enabled = true
+  user_data = local.client_user_data
 
   admin_ssh_key {
     username   = "rocky"
@@ -94,9 +93,9 @@ resource "azurerm_network_interface" "clients_network_interface" {
 # This will cause terraform to not create the driver instance until client is finished
 resource "null_resource" "client_cloud_init_status" {
   connection {
-    type        = "ssh"
-    user        = "rocky"
-    host        = azurerm_linux_virtual_machine.locustclients.0.public_ip_address
+    type  = "ssh"
+    user  = "rocky"
+    host  = azurerm_linux_virtual_machine.locustclients.0.public_ip_address
     agent = true
   }
 

--- a/terraform/azure/driver.tf
+++ b/terraform/azure/driver.tf
@@ -42,16 +42,15 @@ locals {
 }
 
 resource "azurerm_linux_virtual_machine" "driver" {
-  name                       = "p4-benchmark-driver"
-  depends_on                 = [null_resource.helix_core_cloud_init_status, null_resource.client_cloud_init_status]
-  resource_group_name        = azurerm_resource_group.p4benchmark.name
-  location                   = azurerm_resource_group.p4benchmark.location
-  size                       = var.driver_instance_type
-  admin_username             = "rocky"
-  network_interface_ids      = [azurerm_network_interface.driver_network_interface.id]
-  encryption_at_host_enabled = true
-  user_data                  = local.driver_user_data
-  # TODO monitoring, IAM, NSGs
+  name                  = "p4-benchmark-driver"
+  depends_on            = [null_resource.helix_core_cloud_init_status, null_resource.client_cloud_init_status]
+  resource_group_name   = azurerm_resource_group.p4benchmark.name
+  location              = azurerm_resource_group.p4benchmark.location
+  size                  = var.driver_instance_type
+  admin_username        = "rocky"
+  network_interface_ids = [azurerm_network_interface.driver_network_interface.id]
+  user_data             = local.driver_user_data
+  # TODO monitoring, IAM
 
   admin_ssh_key {
     username   = "rocky"
@@ -107,9 +106,9 @@ resource "azurerm_network_interface" "driver_network_interface" {
 # Wait for cloud-init status to complete.
 resource "null_resource" "driver_cloud_init_status" {
   connection {
-    type        = "ssh"
-    user        = "rocky"
-    host        = azurerm_linux_virtual_machine.driver.public_ip_address
+    type  = "ssh"
+    user  = "rocky"
+    host  = azurerm_linux_virtual_machine.driver.public_ip_address
     agent = true
   }
 
@@ -124,9 +123,9 @@ resource "null_resource" "upload_create_files" {
   depends_on = [null_resource.driver_cloud_init_status]
 
   connection {
-    type        = "ssh"
-    user        = "rocky"
-    host        = azurerm_linux_virtual_machine.driver.public_ip_address
+    type  = "ssh"
+    user  = "rocky"
+    host  = azurerm_linux_virtual_machine.driver.public_ip_address
     agent = true
   }
 
@@ -155,9 +154,9 @@ resource "null_resource" "run_create_files" {
   count      = length(var.createfile_configs)
 
   connection {
-    type        = "ssh"
-    user        = "rocky"
-    host        = azurerm_linux_virtual_machine.driver.public_ip_address
+    type  = "ssh"
+    user  = "rocky"
+    host  = azurerm_linux_virtual_machine.driver.public_ip_address
     agent = true
   }
 
@@ -171,9 +170,9 @@ resource "null_resource" "apply_p4d_configurables" {
   depends_on = [null_resource.helix_core_cloud_init_status]
 
   connection {
-    type        = "ssh"
-    user        = "rocky"
-    host        = local.helix_core_public_ip
+    type  = "ssh"
+    user  = "rocky"
+    host  = local.helix_core_public_ip
     agent = true
   }
 
@@ -190,9 +189,9 @@ resource "null_resource" "remove_p4d_configurables" {
   depends_on = [null_resource.run_create_files, null_resource.apply_p4d_configurables]
 
   connection {
-    type        = "ssh"
-    user        = "rocky"
-    host        = local.helix_core_public_ip
+    type  = "ssh"
+    user  = "rocky"
+    host  = local.helix_core_public_ip
     agent = true
   }
 

--- a/terraform/scripts/helix-core-userdata-azure.sh
+++ b/terraform/scripts/helix-core-userdata-azure.sh
@@ -39,6 +39,7 @@ default_userdata_script() {
     hostname "$HOSTNAME"
     echo "$HOSTNAME" > /etc/hostname
 
+    export DEPOT_DEVICE="$(lsscsi [1:0:0:2] | awk '{print $7}')"
     counter=0
     while [ ! -e "$DEPOT_DEVICE" ]; do
         echo "Waiting for $DEPOT_DEVICE to be attached..."
@@ -48,8 +49,11 @@ default_userdata_script() {
             echo "Counter expired waiting for $DEPOT_DEVICE to be attached"
             exit 1
         fi
+        export DEPOT_DEVICE="$(lsscsi [1:0:0:2] | awk '{print $7}')"
     done
 
+    export LOG_DEVICE="$(lsscsi [1:0:0:0] | awk '{print $7}')"
+    export METADATA_DEVICE="$(lsscsi [1:0:0:1] | awk '{print $7}')"
 
     # The AMI is baked with /hx* on the EC2 root volume.  
     # Now that we are starting from CloudFormation we can utilize seperate volumes
@@ -210,10 +214,6 @@ export DEPOT_CONTENT_SNAPSHOT=""
 # export AWS_REGION=$(curl --silent http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
 
 export P4D_AUTH_ID="commit"
-export DEPOT_DEVICE="/dev/sde"
-export LOG_DEVICE="/dev/sdc"
-export METADATA_DEVICE="/dev/sdd"
-
 
 run-parts /home/perforce/.userdata/custom-pre/
 


### PR DESCRIPTION
### Ticket
[69002](https://dev.azure.com/southworks/lycoris/_workitems/edit/69002)

### Changes
- Select disk mount paths via `lsscsi` in `helix-core-userdata-azure.sh`
    - Disk variables can't be evaluated early with `lsscsi` like in ESP. Because the disks are not yet mounted, `lsscsi` returns an empty value. We [moved all definitions to the while loop](https://github.com/aboutte/p4benchmark/pull/3/files#diff-564946de26efe7c98da2e8b22f8686cfb697d3686c7a2295a0bc975aa30a4213R44), to wait for the depot disk mount.
- Remove `encryption_at_host_enabled` for Clients and Driver VMs
- Format Terraform config files to match style