### PR TITLE
[benchmark] Add option to pull in license file from Blob Storage | 69118

### DIFF
--- a/terraform/azure/commit.tf
+++ b/terraform/azure/commit.tf
@@ -5,6 +5,9 @@ locals {
     ssh_public_key      = tls_private_key.ssh-key.public_key_openssh
     ssh_private_key     = tls_private_key.ssh-key.private_key_openssh
     p4benchmark_os_user = var.p4benchmark_os_user
+    license_filename    = var.license_filename
+    blob_account_name   = var.blob_account_name
+    blob_container      = var.blob_container
   }))
 }
 
@@ -38,6 +41,9 @@ resource "azurerm_linux_virtual_machine" "helix_core" {
     name      = "p4d_2020_1_2107780_v2"
     publisher = "perforce"
     product   = "perforce-helix-core-offer"
+  }
+  identity {
+    type = "SystemAssigned"
   }
   tags = local.tags
 }

--- a/terraform/azure/roles.tf
+++ b/terraform/azure/roles.tf
@@ -1,0 +1,12 @@
+data "azurerm_storage_container" "license_container" {
+  count                = var.blob_container != "" ? 1 : 0
+  name                 = var.blob_container
+  storage_account_name = var.blob_account_name
+}
+
+resource "azurerm_role_assignment" "storage_read_role" {
+  count                = var.blob_container != "" ? 1 : 0
+  scope                = data.azurerm_storage_container.license_container[0].resource_manager_id
+  role_definition_name = "Storage Blob Data Reader"
+  principal_id         = azurerm_linux_virtual_machine.helix_core.identity[0].principal_id
+}

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -251,3 +251,21 @@ variable "helix_coreprivate_ip" {
   type        = string
   default     = ""
 }
+
+variable "blob_account_name" {
+  description = "Name of the Account Name in Blob Storage."
+  type        = string
+  default     = ""
+}
+
+variable "blob_container" {
+  description = "Name of the Container in Blob Storage which stores the license."
+  type        = string
+  default     = ""
+}
+
+variable "license_filename" {
+  description = "Name of the license file in Blob Storage."
+  type        = string
+  default     = ""
+}

--- a/terraform/scripts/helix-core-userdata-azure.sh
+++ b/terraform/scripts/helix-core-userdata-azure.sh
@@ -223,4 +223,20 @@ default_userdata_script
 
 run-parts /home/perforce/.userdata/custom-post/
 
-# TODO: Add support for adding a license in Azure Virtual Machine
+if [[ "${license_filename}" != '' ]] ;
+then
+    echo "Pulling down license file from Blob Storage..."
+
+    # TODO: finish support for restoring from archive.tar and checkpoint
+      
+    # Install azcopy and login
+    wget -O azcopy_v10.tar.gz https://aka.ms/downloadazcopy-v10-linux && tar -xf azcopy_v10.tar.gz --strip-components=1
+    ./azcopy login --identity
+
+    # Download license file
+    ./azcopy copy https://${blob_account_name}.blob.core.windows.net/${blob_container}/${license_filename} /p4/1/root/license
+
+    service p4d_1 restart
+    sleep 10  
+    echo "Finished applying the license"
+fi


### PR DESCRIPTION
### Ticket
[69118](https://dev.azure.com/southworks/lycoris/_workitems/edit/69118)

### Changes
- Add variables `blob_account_name`, `blob_container` and `license_filename`. All default to `""`.
- Get an existing Azure Blob Storage Container via `azurerm_storage_container`.
- Assign a System Managed Identity to Helix's VM.
- Assign, to this identity, the role "Storage Blob Data Reader" for the Storage Container.

ℹ️ If a license is specified it's **required** to have an Azure Storage Account already configured. [A default set up works OK](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal).