### PR TITLE
[benchmark] Add support for existing helix-core and VNET | 68972 / 69119

### DIFF
--- a/terraform/azure/README.md
+++ b/terraform/azure/README.md
@@ -4,7 +4,7 @@
 
 Before runnning the Terraform scripts, you'll need to create the SSH Key pair to assign to the machines and add it to your SSH Agent.
 
-_Note: if you are on Windows, execute all of the following commands in Git Bash to ensure compatibility._
+> **Note:** if you are on Windows, execute all of the following commands in Git Bash to ensure compatibility.
 
 1. Make sure your `az` client is correctly installed and configured:
 
@@ -26,8 +26,8 @@ az vm image terms accept --urn perforce:rockylinux8:8-gen2:8.6.2022060701
 3. Create a resource group to hold your public key:
 
 ```bash
-export key_name="fgiordano"
-export key_resource_group_name="fgiordano-keys"
+export key_name="key_name"
+export key_resource_group_name="keys_resource_group"
 location=eastus # Tweak as needed
 
 az group create --name $key_resource_group_name --location $location
@@ -52,16 +52,15 @@ Terraform variables can bet set via environment variables with this syntax TF_VA
 You can configure the variables by creating the file `terraform.tfvars` within this folder with the following:
 
 ```
-owner                         = "Christian Cabrer"
-key_name                      = "ccabrer"
-key_resource_group_name       = "ccabrer-keys"
+owner                         = "Owner Name"
+key_name                      = "key_name"
+key_resource_group_name       = "keys_resource_group"
 ```
 
 Or you can do it using the .envrc file:
 
 ```bash
-export TF_VAR_owner="Christian Cabrer"
-export TF_VAR_key_name="ccabrer"
+export TF_VAR_owner="Owner Name"
 
 # SSH Key
 export TF_VAR_key_name=$key_name
@@ -77,3 +76,31 @@ export TF_VAR_ingress_cidrs_1666="200.80.77.193"
 ```bash
 terraform apply
 ```
+
+## Using existing Helix Core Instance and Virtual Network
+
+To use an existing Helix Core instance and avoid creating a new one, the following variables must be configured, replacing the values with the ones of your instance:
+
+```bash
+# Set the variable to indicate we will use an existing Helix Core instance
+existing_helix_core = true
+# Set the private ip of the existing Helix Core instance
+existing_helix_core_ip = "10.0.0.6"
+# Set the public ip of the existing Helix Core instance
+existing_helix_core_public_ip = "20.127.110.1"
+# Set the username for the P4 running inside the Helix Core instance
+existing_helix_core_username = "username"
+# Set the password for the P4 running inside the Helix Core instance
+existing_helix_core_password = "password"
+
+# Set the variable to indicate we will use an existing Virtual Network
+existing_vnet = true
+# Set resource group to which the Virtual Network belongs
+existing_vnet_resource_group = "p4benchmark"
+# Set the name of the existing Virtual Network
+existing_vnet_name = "p4benchmark"
+# Set the name of the existing subnet connected to the existing Virtual Network
+existing_subnet_name = "public0"
+```
+
+> **Note:** Since the Locust Client uses the Helix Core private IP to connect to Helix Core, when configuring an existing Helix Core, the existing Virtual Network of the instance should be configured as well.

--- a/terraform/azure/clients.tf
+++ b/terraform/azure/clients.tf
@@ -1,8 +1,7 @@
 
 locals {
 
-  # clients_sg_ids   = ... # TODO: support NSGs and existing Helix Core deployment
-  client_subnet_id = azurerm_subnet.vm_p4_subnet.id # TODO: support existing Helix Core deployment
+  client_subnet_id = var.existing_vnet ? data.azurerm_subnet.existing_public_subnet[0].id : azurerm_subnet.vm_p4_subnet[0].id
 
   client_user_data = base64encode(templatefile("${path.module}/../scripts/client_userdata.sh", {
     environment         = var.environment

--- a/terraform/azure/driver.tf
+++ b/terraform/azure/driver.tf
@@ -1,14 +1,12 @@
 
 locals {
 
-  # driver_sg_ids    = var.existing_vpc ? concat(var.existing_sg_ids, [module.driver_sg.security_group_id]) : [module.driver_sg.security_group_id]
-  driver_subnet_id = azurerm_subnet.vm_p4_subnet.id # TODO: support existing deployments
+  driver_subnet_id = var.existing_vnet ? data.azurerm_subnet.existing_public_subnet[0].id : azurerm_subnet.vm_p4_subnet[0].id
 
-  helix_core_commit_username = var.helix_core_commit_username
-  # TODO: support exsiting Helix deployments and connection to commit server
-  helix_core_commit_password = azurerm_linux_virtual_machine.helix_core.virtual_machine_id
-  helix_core_private_ip      = azurerm_linux_virtual_machine.helix_core.private_ip_address
-  helix_core_public_ip       = azurerm_linux_virtual_machine.helix_core.public_ip_address
+  helix_core_commit_username = var.existing_helix_core ? var.existing_helix_core_username : var.helix_core_commit_username
+  helix_core_commit_password = var.existing_helix_core ? var.existing_helix_core_password : azurerm_linux_virtual_machine.helix_core[0].virtual_machine_id
+  helix_core_private_ip      = var.existing_helix_core ? var.existing_helix_core_ip : azurerm_linux_virtual_machine.helix_core[0].private_ip_address
+  helix_core_public_ip       = var.existing_helix_core ? var.existing_helix_core_public_ip : azurerm_linux_virtual_machine.helix_core[0].public_ip_address
 
   driver_user_data = base64encode(templatefile("${path.module}/../scripts/driver_userdata.sh", {
     environment                          = var.environment

--- a/terraform/azure/network.tf
+++ b/terraform/azure/network.tf
@@ -3,6 +3,7 @@ locals {
 }
 
 resource "azurerm_virtual_network" "vm_p4_virtual_network" {
+  count               = var.existing_vnet ? 0 : 1
   name                = "p4benchmark"
   address_space       = [var.vnet_cidr]
   location            = azurerm_resource_group.p4benchmark.location
@@ -15,13 +16,15 @@ resource "azurerm_virtual_network" "vm_p4_virtual_network" {
 ##  private_subnets = [local.subnets[2], local.subnets[3]]
 ##  public_subnets  = [local.subnets[0], local.subnets[1]]
 resource "azurerm_subnet" "vm_p4_subnet" {
+  count                = var.existing_vnet ? 0 : 1
   name                 = "public0"
   resource_group_name  = azurerm_resource_group.p4benchmark.name
-  virtual_network_name = azurerm_virtual_network.vm_p4_virtual_network.name
+  virtual_network_name = azurerm_virtual_network.vm_p4_virtual_network[0].name
   address_prefixes     = [local.subnets[0]]
 }
 
 resource "azurerm_network_security_group" "p4_helix_core_sg" {
+  count               = var.existing_vnet ? 0 : 1
   name                = "p4_helix_core_sg"
   resource_group_name = azurerm_resource_group.p4benchmark.name
   location            = azurerm_resource_group.p4benchmark.location
@@ -29,6 +32,7 @@ resource "azurerm_network_security_group" "p4_helix_core_sg" {
 }
 
 resource "azurerm_network_security_rule" "helix_core_ssh_rule" {
+  count                       = var.existing_vnet ? 0 : 1
   name                        = "SSH"
   priority                    = 100
   direction                   = "Inbound"
@@ -39,12 +43,13 @@ resource "azurerm_network_security_rule" "helix_core_ssh_rule" {
   source_address_prefixes     = var.ingress_cidrs_22
   destination_address_prefix  = "*"
   resource_group_name         = azurerm_resource_group.p4benchmark.name
-  network_security_group_name = azurerm_network_security_group.p4_helix_core_sg.name
+  network_security_group_name = azurerm_network_security_group.p4_helix_core_sg[0].name
 }
 
 resource "azurerm_network_security_rule" "helix_core_perforce_rule" {
+  count                       = var.existing_vnet ? 0 : 1
   name                        = "Perforce"
-  priority                    = 300
+  priority                    = 200
   direction                   = "Inbound"
   access                      = "Allow"
   protocol                    = "Tcp"
@@ -53,11 +58,58 @@ resource "azurerm_network_security_rule" "helix_core_perforce_rule" {
   source_address_prefixes     = var.ingress_cidrs_1666
   destination_address_prefix  = "*"
   resource_group_name         = azurerm_resource_group.p4benchmark.name
-  network_security_group_name = azurerm_network_security_group.p4_helix_core_sg.name
+  network_security_group_name = azurerm_network_security_group.p4_helix_core_sg[0].name
 }
 
+resource "azurerm_network_interface_security_group_association" "vnet_sg_association" {
+  count                     = var.existing_helix_core ? 0 : 1
+  network_interface_id      = azurerm_network_interface.vm_p4_network[0].id
+  network_security_group_id = azurerm_network_security_group.p4_helix_core_sg[0].id
+}
 
-resource "azurerm_network_interface_security_group_association" "example" {
-  network_interface_id      = azurerm_network_interface.vm_p4_network.id
-  network_security_group_id = azurerm_network_security_group.p4_helix_core_sg.id
+resource "azurerm_network_security_group" "p4_driver_sg" {
+  name                = "p4_driver_sg"
+  resource_group_name = azurerm_resource_group.p4benchmark.name
+  location            = azurerm_resource_group.p4benchmark.location
+  tags                = local.tags
+}
+
+resource "azurerm_network_security_rule" "driver_ssh_rule" {
+  name                        = "SSH"
+  priority                    = 100
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
+  source_address_prefixes     = var.ingress_cidrs_22
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.p4benchmark.name
+  network_security_group_name = azurerm_network_security_group.p4_driver_sg.name
+}
+
+resource "azurerm_network_security_rule" "driver_locust_master_rule" {
+  name                        = "locust_master"
+  priority                    = 200
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "5557"
+  source_address_prefixes     = [var.vnet_cidr]
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.p4benchmark.name
+  network_security_group_name = azurerm_network_security_group.p4_driver_sg.name
+}
+
+resource "azurerm_network_interface_security_group_association" "vnet_driver_sg_association" {
+  network_interface_id      = azurerm_network_interface.driver_network_interface.id
+  network_security_group_id = azurerm_network_security_group.p4_driver_sg.id
+}
+
+data "azurerm_subnet" "existing_public_subnet" {
+  count                = var.existing_vnet ? 1 : 0
+  name                 = var.existing_subnet_name
+  virtual_network_name = var.existing_vnet_name
+  resource_group_name  = var.existing_vnet_resource_group
 }

--- a/terraform/azure/outputs.tf
+++ b/terraform/azure/outputs.tf
@@ -15,15 +15,15 @@ output "driver_public_ip" {
 
 output "helix_core_commit_public_ip" {
   description = "Helix Core public IP address"
-  value       = azurerm_linux_virtual_machine.helix_core.public_ip_address
+  value       = var.existing_helix_core ? null : azurerm_linux_virtual_machine.helix_core[0].public_ip_address
 }
 
 output "helix_core_commit_private_ip" {
   description = "Helix Core private IP address"
-  value       = azurerm_linux_virtual_machine.helix_core.private_ip_address
+  value       = var.existing_helix_core ? null : azurerm_linux_virtual_machine.helix_core[0].private_ip_address
 }
 
 output "helix_core_commit_instance_id" {
   description = "Helix Core Instance ID - This is the password for the perforce user"
-  value       = azurerm_linux_virtual_machine.helix_core.virtual_machine_id
+  value       = var.existing_helix_core ? null : azurerm_linux_virtual_machine.helix_core[0].virtual_machine_id
 }

--- a/terraform/azure/roles.tf
+++ b/terraform/azure/roles.tf
@@ -1,12 +1,12 @@
 data "azurerm_storage_container" "license_container" {
-  count                = var.blob_container != "" ? 1 : 0
+  count                = !var.existing_helix_core && var.blob_container != "" ? 1 : 0
   name                 = var.blob_container
   storage_account_name = var.blob_account_name
 }
 
 resource "azurerm_role_assignment" "storage_read_role" {
-  count                = var.blob_container != "" ? 1 : 0
+  count                = !var.existing_helix_core && var.blob_container != "" ? 1 : 0
   scope                = data.azurerm_storage_container.license_container[0].resource_manager_id
   role_definition_name = "Storage Blob Data Reader"
-  principal_id         = azurerm_linux_virtual_machine.helix_core.identity[0].principal_id
+  principal_id         = azurerm_linux_virtual_machine.helix_core[0].identity[0].principal_id
 }

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -96,6 +96,60 @@ variable "helix_core_depot_volume_size" {
   default     = 512
 }
 
+variable "existing_vnet" {
+  description = "Whether or not to use an existing vnet or create one"
+  type        = bool
+  default     = false
+}
+
+variable "existing_helix_core" {
+  description = "Whether or not to use an existing Helix Core or create one"
+  type        = bool
+  default     = false
+}
+
+variable "existing_vnet_resource_group" {
+  description = "Existing resource group to which the VNet belongs"
+  type        = string
+  default     = ""
+}
+
+variable "existing_vnet_name" {
+  description = "Existing VNet name to use for VM deployments"
+  type        = string
+  default     = ""
+}
+
+variable "existing_subnet_name" {
+  description = "Existing subnet name to use for VM deployments"
+  type        = string
+  default     = ""
+}
+
+variable "existing_helix_core_ip" {
+  description = "Existing helix core IP for locust clients to use for P4PORT"
+  type        = string
+  default     = ""
+}
+
+variable "existing_helix_core_public_ip" {
+  description = "Existing helix core public IP for terraform to connect via remote-exec for configuration"
+  type        = string
+  default     = ""
+}
+
+variable "existing_helix_core_username" {
+  description = "Existing helix core username for locust clients to use for P4USER"
+  type        = string
+  default     = ""
+}
+
+variable "existing_helix_core_password" {
+  description = "Existing helix core password for locust clients to use for p4 login"
+  type        = string
+  default     = ""
+}
+
 # Shared Helix Core, Locust Clients And Driver VMs Variables
 
 variable "p4benchmark_os_user" {


### PR DESCRIPTION
### Ticket

[68972: Add option to use existing Helix Core](https://dev.azure.com/southworks/lycoris/_workitems/edit/68972)
[69119: Support existing VNET](https://dev.azure.com/southworks/lycoris/_workitems/edit/69119)

### Changes
- Updated [README.md](https://github.com/aboutte/p4benchmark/pull/6/files#diff-20cf853b8fd88aee7de57017d7e36eee929edc3fac1e0ce2610b1f86a2445513) with instructions to use an existing Helix Core and VNet.
- Update [clients.tf](https://github.com/aboutte/p4benchmark/pull/6/files#diff-916c726f10b2dbc014a48eb328712978717b6ee083f9cbc3a14cd1d3e04afe42) to use an existing VNet.
- Update [commit.tf](https://github.com/aboutte/p4benchmark/pull/6/files#diff-affff6c4ef7806bee78b8ff0f0b641d82d2d2647ca7334b874d095408b4a5ad3) to not create Helix Core instance if an existing one is going to be used.
- Update [driver.tf](https://github.com/aboutte/p4benchmark/pull/6/files#diff-d351b760e2b6236a4d8e09ba00d695cd47c3f45afe08434da453f11a858ecc09) to use existing Helix Core instance and existing VNet.
- Update [network.tf](https://github.com/aboutte/p4benchmark/pull/6/files#diff-205c544722ac627ed580eccac8b611694272c26dd5ee6642d1a33f777987a3a3) to use existing VNet and avoid creating a new one.
- Update [roles.tf](https://github.com/aboutte/p4benchmark/pull/6/files#diff-16e761da6a5848aa7a34a8552ce5c430b4617a0a7a705df7bdbda101d261c168) to not create the roles if an existing Helix Core instance is going to be used.
- Add configuration variables on [variables.tf](https://github.com/aboutte/p4benchmark/pull/6/files#diff-8596d9a332fcb3f80c221f35a3e2ea9e20a70b79a9e72ea7eeec7b0b04f21687) to use existing Helix Core instance and existing VNet.