### PR TITLE
[benchmark] Add conditional to each ansible playbook that require SSH into the Helix Core instance | 69522 

### DIFF
--- a/utils/analyse.sh
+++ b/utils/analyse.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Default usage:
+#   ./analyse.sh
+# If you do not have SSH access to the commit server add an argument to avoid the execution of
+# the steps which requires it. 
+# The variable AVOID_SSH_EXECUTIONS will be set with the input and the default value is false.
+# Usage:
+#   ./analyse.sh true
 
 function bail () { echo "\nError: ${1:-Unknown Error}\n"; exit ${2:-1}; }
 
@@ -19,10 +26,13 @@ rundir=$P4BENCH_HOME/run/$runid
 echo "Creating $rundir"
 
 # copy logs - server logs for analysis and clients just in case
+AVOID_SSH_EXECUTIONS=${1:-false}
+echo "Avoid ssh executions: ${AVOID_SSH_EXECUTIONS}"
+
 echo "Copying logs..."
-ansible-playbook -i $ANSIBLE_HOSTS ansible/copy_server_logs.yml > /dev/null
+[[ $AVOID_SSH_EXECUTIONS != "true" ]] && ansible-playbook -i $ANSIBLE_HOSTS ansible/copy_server_logs.yml > /dev/null
 ansible-playbook -i $ANSIBLE_HOSTS ansible/copy_client_logs.yml > /dev/null
-ansible-playbook -i $ANSIBLE_HOSTS ansible/rm_server_logs.yml > /dev/null
+[[ $AVOID_SSH_EXECUTIONS != "true" ]] && ansible-playbook -i $ANSIBLE_HOSTS ansible/rm_server_logs.yml > /dev/null
 
 mkdir $rundir
 pushd $rundir


### PR DESCRIPTION
### Ticket

[69522 : Add conditional to each ansible playbook that require SSH into the Helix Core instance](https://dev.azure.com/southworks/lycoris/_workitems/edit/69522 )

### Changes
- Add a condition to the `utils/run_bench.sh` script to avoid executing the ansible-playbook which requires the connection via SSH with the Helix Core instance.
- Add a condition to the `utils/analyse.sh` script to avoid executing the ansible-playbook which requires the connection via SSH with the Helix Core instance.

