### PR TITLE
[benchmark] Implement static bench using only local files | 70442

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ terraform.tfvars
 
 # Ignore private keys
 *.pem
+
+# Ignore local changesets
+/changeset

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile
-      target: p4bench
+      target: p4benchclient
     hostname: client1
     command: /usr/sbin/sshd -D
     networks:
@@ -47,7 +47,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile
-      target: p4bench
+      target: p4benchclient
     hostname: client2
     command: /usr/sbin/sshd -D
     networks:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Robert Cowham "rcowham@perforce.com"
 # basis for master machine.
 
 RUN yum update -y; \
-    yum install -y net-tools; \
+    yum install -y net-tools iproute; \
     yum install -y perl; \
     yum install -y sudo; \
     yum install -y wget; \
@@ -106,10 +106,8 @@ FROM p4bench as p4benchdriver
 
 USER root
 
-RUN dnf install --assumeyes epel-release; \
-    dnf install --assumeyes ansible; \
-    dnf install --assumeyes cronie; \
-    dnf install --assumeyes sqlite nc
+RUN dnf install --assumeyes epel-release
+RUN dnf install --assumeyes ansible cronie sqlite nc
 
 # Log analyzer required
 RUN mkdir /home/perforce/bin; \
@@ -130,3 +128,10 @@ ADD ansible/* /p4/benchmark/ansible/
 ADD utils/* /p4/benchmark/utils/
 ADD hosts.docker.yaml /p4/benchmark/
 ADD docker/docker_entry_p4bench.sh /p4/benchmark/
+
+# ==================================================================
+# Dockerfile for benchmark client target - builds on the base
+FROM p4bench as p4benchclient
+
+RUN mkdir -p /tmp/changeset
+ADD changeset/* /tmp/changeset/

--- a/docker/docker_entry_p4bench.sh
+++ b/docker/docker_entry_p4bench.sh
@@ -43,7 +43,7 @@ EOF
 
 mkdir run logs
 echo "Starting benchmark (including initialisation)"
-./utils/run_bench.sh 1 basic 
+./utils/run_bench.sh 1 static 
 echo "Waiting for benchmark to complete"
 sleep 10
 ./utils/wait_end_bench.sh

--- a/hosts.docker.yaml
+++ b/hosts.docker.yaml
@@ -20,7 +20,7 @@ all:
     # The port to use
     p4port: 1666
     # Number of workers per bench_client
-    num_workers: 12
+    num_workers: 2
 
     # This section is mainly for the locust scripts more than the yaml files
     general:
@@ -44,9 +44,9 @@ all:
         #   If it includes "*" will be used as base for selection after running "p4 dirs" on it
         repoPath:   //depot/*
         # repoDirNum: (numeric) Number of entries to randomly select from the above "p4 dirs" output if relevant
-        repoDirNum: 2
+        repoDirNum: 5
         # How many times to repeat the loop
-        repeat: 5
+        repeat: 15
         # sync_args: any extra sync arguments. This will result in the spawning of a "p4" command
         # Example to avoid actually writing files to filesystem on client side:
         #sync_args: -vfilesys.client.nullsync=1

--- a/locust_files/p4_static.py
+++ b/locust_files/p4_static.py
@@ -1,0 +1,120 @@
+#! /usr/bin/env python3
+#
+# Perforce benchmarks using Locust.io framework
+#
+# Copyright (C) 2016, Robert Cowham, Perforce
+#
+
+from __future__ import print_function
+
+import os
+import sys
+import logging
+from locust import User, events, task, TaskSet
+from locust.exception import StopUser
+import P4
+
+from p4benchutils import popen, fmtsize, readConfig, Timer, P4Benchmark
+
+from locust.stats import RequestStats
+def noop(*arg, **kwargs):
+    logger.info("Stats reset prevented by monkey patch!")
+RequestStats.reset_all = noop
+
+python3 = sys.version_info[0] >= 3
+
+logger = logging.getLogger("static")
+
+startdir = os.getcwd()
+
+CONFIG_FILE = os.getenv("ANSIBLE_HOSTS")   # Configuration parameters
+CHANGESET_SRC_PATH = '/tmp/changeset'      # Directory to copy files from
+
+class P4BasicBenchmark(P4Benchmark):
+    """Performs basic benchmark test - Perforce specific subclass"""
+
+    def __init__(self, startdir, config):
+        super(P4BasicBenchmark, self).__init__(logger, startdir, config, "static")
+
+def writeActions(bench, request_type):
+    "Just add files and submit"
+
+    count = 0
+    t = Timer(request_type)
+    name = "actions"
+    try:
+        count = bench.writeOnly(CHANGESET_SRC_PATH)
+        t.report_success(name, count)
+    except Exception as e:
+        logger.exception(e)
+        t.report_failure(name, e, count)
+
+def readActions(bench, request_type):
+    "read actions (just workspace syncs)"
+    
+    count = 0
+    t = Timer(request_type)
+    name = "actions"
+    try:
+        count = bench.readOnly()
+        t.report_success(name, count)
+    except Exception as e:
+        logger.exception(e)
+        t.report_failure(name, e, count)
+
+class AllTasks(TaskSet):
+    """Entry point for locust"""
+
+    min_wait = 1000
+    max_wait = 3000
+    request_type = "p4"
+
+    def __init__(self, *args, **kwargs):
+        super(AllTasks, self).__init__(*args, **kwargs)
+        self.config = readConfig(startdir, CONFIG_FILE)
+        self.min_wait = self.config["general"]["min_wait"]
+        self.max_wait = self.config["general"]["max_wait"]
+        self.repeat_count = 0
+        if "repeat" in self.config["perforce"]:
+            self.repeat_count = self.config["perforce"]["repeat"]
+        self.count = 0
+        self.task_name = "p4basic"
+        self.bench = P4BasicBenchmark(startdir, self.config)
+
+    def on_start(self):
+        count = 0
+        t = Timer(self.request_type)
+        name = "create"
+        try:
+            self.bench.createWorkspace()
+            count = 1
+            t.report_success(name, count)
+        except Exception as e:
+            logger.exception(e)
+            t.report_failure(name, e, count)
+        t = Timer(self.request_type)
+        name = "sync"
+        try:
+            count = self.bench.syncWorkspace(t)
+            t.report_success(name, count)
+        except Exception as e:
+            logger.exception(e)
+            t.report_failure(name, e, count)
+
+    @task
+    def writeActions(self):
+        logger.info("Starting static write %s" % self.task_name)
+        writeActions(self.bench, self.task_name)
+        logger.info("Finished static write %s" % self.task_name)
+
+        logger.info("Starting static read %s" % self.task_name)
+        readActions(self.bench, self.task_name)
+        logger.info("Finished static read %s" % self.task_name)
+
+        self.count += 1
+        if self.repeat_count and self.count >= self.repeat_count:
+            raise StopUser(self.task_name)   # Die if done
+
+class P4RepoTestLocust(User):
+    """Will be imported and then run by locust"""
+    tasks = [AllTasks]


### PR DESCRIPTION
ℹ️ **This PR is pointing to the [`main`](https://github.com/aboutte/p4benchmark/tree/main) branch instead of [`static`](https://github.com/aboutte/p4benchmark/tree/static). This is because `static` is 28 commits behind from main**. You can see a comparison with [`static` here](https://github.com/southworks/p4benchmark/compare/static..features/70442-local-static-bench#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R37) (most changes in this PR are in p4benchutils.py, p4_static.py and Docker files. The rest come from previous merge commits)

### Ticket
[70442](https://dev.azure.com/southworks/lycoris/_workitems/edit/70442): Implement static bench using only local files

### Description
ℹ️ The goal of this PR is to implement **static bench only with local files** (i.e. copying local changeset paths) and not NFS. This way both tasks could be completed in parallel. NFS mounting and unzipping will be implemented in a different PR.

This PR implements changes to static bench, so that it follows the logic detailed below:
- Create a random workspace for each iteration named `"{self.p4.user}.{uuid}.{self.id}.{platform.node()}"`
- Don't create random files during execution. Instead, copy from `/tmp/changeset` into a top-level folder inside the P4 Depot view.
- Add the new directory to P4
- Submit it.
- Remove the local workspace, to free space in the Client VM

Runs proved consistent when executing tests with small changesets (couple of files). See warning (⚠️) below.
_Note: between each test, we executed `docker-compose down` in order to reset the Helix server._

### Changes
Implementation wise, the code is pretty succinct. Some design decisions we've taken are documented below:
- To add all files under the copied changeset directory, we used the built-in [P4 Wildcard `...`](https://www.perforce.com/manuals/p4guide/Content/P4Guide/syntax.syntax.wildcards.html) This way all files get added without having to iterate over the directory tree. When trying to use the `*` wildcard, changes were rejected by the P4 Client with `Can't add filenames with wildcards [@#%*] in them.`
- To make sure the complete depot is synced from scratch on each iteration, we now re-define [`self.workspace_root` in `readOnly`](https://github.com/aboutte/p4benchmark/pull/13/files#diff-b0dce0b0d4a5fb0ae163200ec2244654453df8862677ab0b6d8b641fb1113bb9R234). Previously, the directory remained the same for all loops, so only minor changes were synced. 
- In line with the previous change, we now remove the current workspace from disk after committing our changes. 
- For local testing, we tweaked the Client's Dockerfile image to [copy a local `changeset` directory into the expected `/tmp/changeset` path](https://github.com/aboutte/p4benchmark/pull/13/files#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcR132-R137).
- ⚠️ When doing local tests with bigger changesets (100 files), we got license-related errors like `Maximum users/clients AND maximum files (1000) exceeded.` and `Can't add client - over license quota ... License count: 20 clients used of 20 licensed.` This produced inconsistent results and metrics. Given that we'll perform these tests in licensed Helix servers and that [unlicensed Helix deployments are file-limited](https://portal.perforce.com/s/article/3159), we've decided to go ahead with this implementation and start working in the integration with NFS storage.
- Changeset path is not configurable (fixed to `/tmp/changeset`), but it gets injected from `p4_static.py` instead of `p4benchutils.py`. This way we can freely decide the path in `p4_static` in future iterations.
- Previous versions selected the changeset destination via `self.localfilelist`. This approach sometimes produced max-length errors because folders could get deeply nested (errors when P4-adding, like `Identifiers too long. Must not be longer than 1024 bytes of UTF-8.`). Because of this, we now select a top-level folder inside the Client view via[ `self._getFirstPathInView` ](https://github.com/aboutte/p4benchmark/pull/13/files#diff-b0dce0b0d4a5fb0ae163200ec2244654453df8862677ab0b6d8b641fb1113bb9R244-R251)using `p4.fetch_client` and `p4.run_where`.
    - Our first approach to solve this problem was to simply query the local filesystem and select the first folder we found inside the depot. The problem with this is that, if the view is ever built different than expected (in [`self.getView`](https://github.com/aboutte/p4benchmark/blob/6da139b19d7a12acb898414e357dbec3c422901e/locust_files/p4benchutils.py#L146)), the benchmark could throw errors when adding the files (e.g. `file(s) not in view`). Taking this into account, we decided to select the top-level folder via P4-native commands.