### PR TITLE
Static bench: Mount File Share and unzip files in Client VMs | 70444

### DIFF
--- a/terraform/azure/README.md
+++ b/terraform/azure/README.md
@@ -77,6 +77,8 @@ export TF_VAR_ingress_cidrs_1666="200.80.77.193"
 terraform apply
 ```
 
+<br>
+
 ## Using existing Helix Core Instance and Virtual Network
 
 To use an existing Helix Core instance and avoid creating a new one, the following variables must be configured, replacing the values with the ones of your instance:
@@ -104,3 +106,17 @@ existing_subnet_name = "public0"
 ```
 
 > **Note:** Since the Locust Client uses the Helix Core private IP to connect to Helix Core, when configuring an existing Helix Core, the existing Virtual Network of the instance should be configured as well.
+
+
+<br>
+
+## Static Benchmark Changeset Setup
+
+In order to use the changeset hosted in Azure Files for the static benchmark, the following variables must be configured in **terraform/azure/variables.tf**:
+
+* `changeset_resource_group_name`
+* `changeset_storage_account_name`
+* `changeset_storage_account_key`
+* `changeset_file_share_name`
+* `changeset_file_share_folder_name`
+* `changeset_destination_path`

--- a/terraform/azure/clients.tf
+++ b/terraform/azure/clients.tf
@@ -3,7 +3,7 @@ locals {
 
   client_subnet_id = var.existing_vnet ? data.azurerm_subnet.existing_public_subnet[0].id : azurerm_subnet.vm_p4_subnet[0].id
 
-  client_user_data = base64encode(templatefile("${path.module}/../scripts/client_userdata.sh", {
+  client_user_data = base64encode(templatefile("${path.module}/../scripts/client_userdata_azure.sh", {
     environment         = var.environment
     ssh_public_key      = tls_private_key.ssh-key.public_key_openssh
     ssh_private_key     = tls_private_key.ssh-key.private_key_openssh
@@ -20,6 +20,13 @@ locals {
 
     p4benchmark_dir      = var.p4benchmark_dir
     locust_workspace_dir = var.locust_workspace_dir
+
+    changeset_resource_group_name    = var.changeset_resource_group_name
+    changeset_storage_account_name   = var.changeset_storage_account_name
+    changeset_storage_account_key    = var.changeset_storage_account_key
+    changeset_file_share_name        = var.changeset_file_share_name
+    changeset_file_share_folder_name = var.changeset_file_share_folder_name
+    changeset_destination_path       = var.changeset_destination_path
 
   }))
 }
@@ -62,6 +69,11 @@ resource "azurerm_linux_virtual_machine" "locustclients" {
     publisher = "perforce"
     product   = "rockylinux8"
   }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
   tags = local.tags
 }
 

--- a/terraform/azure/providers.tf
+++ b/terraform/azure/providers.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  features {    
+  features {
     resource_group {
       prevent_deletion_if_contains_resources = var.prevent_deletion_if_contains_resources
     }

--- a/terraform/azure/resource_group.tf
+++ b/terraform/azure/resource_group.tf
@@ -2,5 +2,5 @@
 resource "azurerm_resource_group" "p4benchmark" {
   name     = "p4benchmark-${lower(replace(var.owner, " ", "-"))}"
   location = var.azure_region
-  tags = local.tags
+  tags     = local.tags
 }

--- a/terraform/azure/roles.tf
+++ b/terraform/azure/roles.tf
@@ -23,3 +23,14 @@ resource "azurerm_role_assignment" "aks_role" {
   role_definition_name = "Azure Kubernetes Service Cluster User Role"
   principal_id         = azurerm_linux_virtual_machine.driver.identity[0].principal_id
 }
+
+data "azurerm_subscription" "subscription_data" {
+}
+
+resource "azurerm_role_assignment" "subscription_read_role_client_vms" {
+  count = length(azurerm_linux_virtual_machine.locustclients)
+
+  scope                = data.azurerm_subscription.subscription_data.id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_linux_virtual_machine.locustclients[count.index].identity[0].principal_id
+}

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -383,3 +383,39 @@ variable "prevent_deletion_if_contains_resources" {
   type        = bool
   default     = false
 }
+
+variable "changeset_resource_group_name" {
+  description = "Name of the Azure resource group where the changeset storage account is located"
+  type        = string
+  default     = ""
+}
+
+variable "changeset_storage_account_name" {
+  description = "Name of the Azure storage account where the changeset file share is located"
+  type        = string
+  default     = ""
+}
+
+variable "changeset_storage_account_key" {
+  description = "Key of the Azure storage account where the changeset file share is located"
+  type        = string
+  default     = ""
+}
+
+variable "changeset_file_share_name" {
+  description = "Name of the Azure file share where the changeset is located"
+  type        = string
+  default     = ""
+}
+
+variable "changeset_file_share_folder_name" {
+  description = "Name of the Azure file share folder where the changeset is located"
+  type        = string
+  default     = ""
+}
+
+variable "changeset_destination_path" {
+  description = "Destination path in client VMs for the changeset extracted files"
+  type        = string
+  default     = "/tmp/changeset"
+}

--- a/terraform/scripts/client_userdata_azure.sh
+++ b/terraform/scripts/client_userdata_azure.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+trap 'catch $? $LINENO' ERR
+
+catch() {
+    echo ""
+    echo "ERROR CAUGHT!"
+    echo ""
+    echo "Error code $1 occurred on line $2"
+    echo ""
+    
+    exit $1
+}
+
+useradd perforce
+
+mkdir -p /home/${p4benchmark_os_user}/.ssh/
+touch /home/${p4benchmark_os_user}/.ssh/authorized_keys
+chown -R ${p4benchmark_os_user}:${p4benchmark_os_user} /home/${p4benchmark_os_user}
+
+echo 'perforce ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/perforce
+
+echo "${ssh_public_key}" > /ssh_public_key
+echo "${ssh_public_key}" >> /home/${p4benchmark_os_user}/.ssh/authorized_keys
+echo "${ssh_private_key}" > /ssh_private_key
+
+cat << EOF > /etc/yum.repos.d/perforce.repo
+[Perforce]
+name=Perforce
+baseurl=https://package.perforce.com/yum/rhel/8/x86_64
+enabled=1
+gpgcheck=1
+EOF
+
+rpm --import https://package.perforce.com/perforce.pubkey
+
+yum group install -y "Development Tools"  --nogpgcheck
+yum install -y helix-p4d epel-release sqlite wget jq vim net-tools perl nmap-ncat python38 python38-devel python3-pip perforce-p4python3-python3.8 cifs-utils
+yum remove -y python36 python39
+
+echo /usr/local/lib>> /etc/ld.so.conf
+echo /usr/lib64>> /etc/ld.so.conf
+
+# copy down the project from github just so we can get the requirments.txt file
+# laster the driver VM will use ansible to copy over the required files
+cd /tmp
+git clone https://github.com/${git_owner}/${git_project}.git
+cd ${git_project}/
+git checkout ${git_branch}
+
+cd locust_files
+pip3 install -r requirements.txt
+
+rm -rf /tmp/${git_project}
+
+mkdir -p /${p4benchmark_dir}
+chown -R ${p4benchmark_os_user}:${p4benchmark_os_user} ${p4benchmark_dir}
+
+mkdir -p /${locust_workspace_dir}
+chown -R ${p4benchmark_os_user}:${p4benchmark_os_user} ${locust_workspace_dir}
+
+
+cat << EOF >> /etc/security/limits.conf
+
+perforce        hard nofile 10000
+perforce        soft nofile 10000
+EOF
+
+
+# the python code does a login but not a trust
+# the user data cant do a login at this point because the p4benchmark_os_user is created by the driver
+# vm which is created after the client VMs
+export P4TRUST="/home/${p4benchmark_os_user}/.p4trust"
+export P4PORT="ssl:${helix_core_private_ip}:${helix_core_port}"
+p4 trust -y
+chown ${p4benchmark_os_user}:${p4benchmark_os_user} /home/${p4benchmark_os_user}/.p4*
+
+
+# static benchmark changeset setup
+if [[ "${changeset_resource_group_name}" != '' && "${changeset_storage_account_name}" != '' && "${changeset_storage_account_key}" != '' && "${changeset_file_share_name}" != '' && "${changeset_file_share_folder_name}" != '' ]] ;
+then
+cd /
+
+echo "Installing az CLI..."
+rpm --import https://packages.microsoft.com/keys/microsoft.asc 
+
+sh -c 'echo -e "[azure-cli]
+name=Azure CLI
+baseurl=https://packages.microsoft.com/yumrepos/azure-cli
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo'
+yum install azure-cli -y
+
+echo "Login to az CLI"
+az login --identity
+
+mntRoot="/mount"
+mntPath="$mntRoot/changeset"
+mkdir -p $mntPath
+
+httpEndpoint=$(az storage account show --resource-group ${changeset_resource_group_name} --name ${changeset_storage_account_name} --query "primaryEndpoints.file" --output tsv | tr -d '"')
+smbPath=//$(echo $httpEndpoint | cut -d '/' -f 3)/${changeset_file_share_name}/${changeset_file_share_folder_name}
+echo "smbPath=$smbPath"
+
+sudo mount -t cifs $smbPath $mntPath -o username=${changeset_storage_account_name},password=${changeset_storage_account_key},serverino,nosharesock,actimeo=30
+
+mkdir -p ${changeset_destination_path}
+tar xvzf $mntPath/files.tar.gz -C ${changeset_destination_path}
+fi


### PR DESCRIPTION
### Ticket

[70444](https://dev.azure.com/southworks/lycoris/_workitems/edit/70444) **Static bench: Mount changeset and unzip files in Client VMs**

### Changes

* Added necessary code to mount Azure Files share containing the changeset that will be used for the static benchmark

### Details

* Added new file **client_userdata_azure.sh** which is a copy of **client_userdata.sh** plus the necessary code to mount the Azure Files share
* Added new Terraform variables
  * `changeset_resource_group_name`
  * `changeset_storage_account_name`
  * `changeset_storage_account_key`
  * `changeset_file_share_name`
  * `changeset_file_share_folder_name`
  * `changeset_destination_path`
* Added new role to allow the VM retrieve Azure Files share information to perform the mount
* Updated terraform/azure/README.md to include changeset setup info
